### PR TITLE
fix(nix): Add empty image config to allow k8s usage

### DIFF
--- a/build-registry-image.nix
+++ b/build-registry-image.nix
@@ -133,6 +133,8 @@ let
     os = "linux";
     rootfs.type = "layers";
     rootfs.diff_ids = map (layer: "sha256:${layer.sha256}") allLayers;
+    # Required to let Kubernetes import Nixery images
+    config = {};
   };
   configJson = writeText "${baseName}-config.json" (builtins.toJSON config);
   configMetadata = with builtins; fromJSON (readFile (runCommand "config-meta" {


### PR DESCRIPTION
Introduce an empty runtime configuration object in each built layer.

This is required because Kubernetes expects the configuration to be
present (even if it's just empty values).

Providing an empty configuration will make Docker's API return a full
configuration struct with default (i.e. empty) values rather than
`null`, which works for Kubernetes.

This fixes issue #1. See the issue for additional details.