### PR TITLE
Return more structured error information to registry clients

### DIFF
--- a/build-registry-image.nix
+++ b/build-registry-image.nix
@@ -208,7 +208,7 @@ let
   } ''
     size=$(wc -c ${configJson} | cut -d ' ' -f1)
     sha256=$(sha256sum ${configJson} | cut -d ' ' -f1)
-    md5=$(openssl dgst -md5 -binary $layerPath | openssl enc -base64)
+    md5=$(openssl dgst -md5 -binary ${configJson} | openssl enc -base64)
     jq -n -c --arg size $size --arg sha256 $sha256 --arg md5 $md5 \
       '{ size: ($size | tonumber), sha256: $sha256, md5: $md5 }' \
       >> $out

--- a/main.go
+++ b/main.go
@@ -362,6 +362,7 @@ func (h *registryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			log.Println("Failed to build image manifest", err)
+			w.WriteHeader(500)
 			return
 		}
 


### PR DESCRIPTION
Ensures that errors are returned with actual status codes, for example for cases where packages could not be found (-> 404).

See individual commits for details. This fixes #11.