### PR TITLE
Note that the demo instance is just a demo

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -89,6 +89,16 @@
         Google.
       </li>
       <li>
+        <strong>Can I depend on the demo instance in production?</strong>
+        <br>
+        <strong>No.</strong> The demo instance is just a demo. It
+        might go down, move, or disappear entirely at any point.
+        <br>
+        To make use of Nixery in your project, please deploy a private
+        instance. Stay tuned for instructions for how to do this on
+        GKE.
+      </li>
+      <li>
         <strong>Who made this?</strong>
         <br>
         <a href="https://github.com/tazjin">tazjin</a>


### PR DESCRIPTION
People should not start depending on the demo instance. There have
been discussions around making a NixOS-official instance, but the
project needs to mature a little bit first.