### PR TITLE
Fix missing launch script dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -95,6 +95,7 @@ rec {
     config.Cmd = ["${nixery-launch-script}/bin/nixery"];
     contents = [
       cacert
+      coreutils
       git
       gnutar
       gzip


### PR DESCRIPTION
Mea culpa! My current local test setup does not cover the final image, and I should probably fix that.