### PR TITLE
Use Cachix for Nix artifact caching in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: nix
+before_script:
+  - nix-env -iA nixpkgs.cachix
+  - cachix use nixery
+script:
+  - nix-build | cachix push nixery

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}
+, preLaunch ? "" }:
 
 with pkgs;
 
@@ -87,6 +88,8 @@ rec {
       # Disable sandboxing to avoid running into privilege issues
       mkdir -p /etc/nix
       echo 'sandbox = false' >> /etc/nix/nix.conf
+
+      ${preLaunch}
 
       exec ${nixery-bin}/bin/nixery
     '';


### PR DESCRIPTION
Makes use of [Cachix](https://cachix.org) for Nix-caching. See commits for details.