### PR TITLE
fix(go): Fix breakage in unsigned URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -328,7 +328,7 @@ func constructLayerUrl(cfg *config, digest string) (string, error) {
 		opts.Expires = time.Now().Add(5 * time.Minute)
 		return storage.SignedURL(cfg.bucket, object, &opts)
 	} else {
-		return ("https://storage.googleapis.com" + cfg.bucket + "/" + object), nil
+		return ("https://storage.googleapis.com/" + cfg.bucket + "/" + object), nil
 	}
 }
 


### PR DESCRIPTION
This affected the public instance which is still running without URL signing.

To catch this stuff I've now set up monitoring on the public instance:

![Nixery monitoring](https://i.imgur.com/spemeMt.png)

The public instance should eventually transition to signed URls, too.