### PR TITLE
Significantly increase maximum number of layers

### DIFF
--- a/build-registry-image.nix
+++ b/build-registry-image.nix
@@ -29,11 +29,10 @@
   packages ? "[]",
   # Optional bash script to run on the files prior to fixturizing the layer.
   extraCommands ? "", uid ? 0, gid ? 0,
-  # Docker's lowest maximum layer limit is 42-layers for an old
-  # version of the AUFS graph driver. We pick 24 to ensure there is
-  # plenty of room for extension. I believe the actual maximum is
-  # 128.
-  maxLayers ? 24,
+  # Docker's modern image storage mechanisms have a maximum of 125
+  # layers. To allow for some extensibility (via additional layers),
+  # the default here is set to something a little less than that.
+  maxLayers ? 96,
 
   # Configuration for which package set to use when building.
   #

--- a/default.nix
+++ b/default.nix
@@ -30,7 +30,6 @@ rec {
     # or similar (as other required files will not be included), but
     # buildGoPackage requires a package path.
     goPackagePath = "github.com/google/nixery";
-
     goDeps = ./go-deps.nix;
     src    = ./.;
 
@@ -116,6 +115,7 @@ rec {
   in dockerTools.buildLayeredImage {
     name = "nixery";
     config.Cmd = ["${nixery-launch-script}/bin/nixery"];
+    maxLayers = 96;
     contents = [
       cacert
       coreutils

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -24,8 +24,8 @@ let
   nix-1p = fetchFromGitHub {
     owner  = "tazjin";
     repo   = "nix-1p";
-    rev    = "aab846cd3d79fcd092b1bfea1346c587b2a56095";
-    sha256 = "12dl0xrwgg2d4wyv9zxgdn0hzqnanczjg23vqn3356rywxlzzwak";
+    rev    = "3cd0f7d7b4f487d04a3f1e3ca8f2eb1ab958c49b";
+    sha256 = "02lpda03q580gyspkbmlgnb2cbm66rrcgqsv99aihpbwyjym81af";
   };
 in runCommand "nixery-book" {} ''
   mkdir -p $out


### PR DESCRIPTION
`buildLayeredImage` has a notion of maximum image layers, which determine how well the algorithm can group derivations that should be in their own layers to avoid cache busts.

Setting this number involves a tradeoff where we pay for better caching characteristics by sacrificing extensibility (the closer it gets to Docker's maximum of 125, the fewer additional layers users can add on top) and pull speed (concurrency limits during pulls might impact large pulls). The latter two don't really matter much for Nixery's intended use-cases though, so it's worth experimenting with this.

Tangentially related to #15.