### PR TITLE
Add an integration test that runs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,51 @@
 language: nix
+services:
+  - docker
 before_script:
-  - nix-env -iA nixpkgs.cachix
-  - cachix use nixery
+  - |
+    mkdir test-files
+    echo ${GOOGLE_KEY} | base64 -d > test-files/key.json
+    echo ${GCS_SIGNING_PEM} | base64 -d > test-files/gcs.pem
+    nix-env -iA nixpkgs.cachix -A nixpkgs.go
+    cachix use nixery
 script:
+  - test -z $(gofmt -l server/ build-image/)
   - nix-build | cachix push nixery
+
+  # This integration test makes sure that the container image built
+  # for Nixery itself runs fine in Docker, and that images pulled
+  # from it work in Docker.
+  #
+  # Output from the Nixery container is printed at the end of the
+  # test regardless of test status.
+  - IMG=$(docker load -q -i $(nix-build -A nixery-image) | awk '{ print $3 }')
+  - echo "Loaded Nixery image as ${IMG}"
+
+  - |
+    docker run -d -p 8080:8080 --name nixery \
+      -v ${PWD}/test-files:/var/nixery \
+      -e PORT=8080 \
+      -e BUCKET=nixery-layers \
+      -e GOOGLE_CLOUD_PROJECT=nixery \
+      -e GOOGLE_APPLICATION_CREDENTIALS=/var/nixery/key.json \
+      ${IMG}
+
+  # print all of the container's logs regardless of success
+  - |
+    function print_logs {
+      echo "Nixery container logs:"
+      docker logs nixery
+    }
+    trap print_logs EXIT
+
+  # Give the container ~20 seconds to come up
+  - |
+    attempts=0
+    echo -n "Waiting for Nixery to start ..."
+    until $(curl --fail --silent "http://localhost:8080/v2/"); do
+      [[ attempts -eq 30 ]] && echo "Nixery container failed to start!" && exit 1
+      ((attempts++))
+      echo -n "."
+      sleep 1
+    done
+  - docker run --rm localhost:8080/hello hello


### PR DESCRIPTION
This test, after performing the usual Nixery build, loads the built
image into Docker, runs it, pulls an image from Nixery and runs that
image.

Currently tested:

* [x] Nixery's own Nix build
* [x] Nixery's own Nix-built container image
* [x] Nixery's ability to `nix-build` container images
* [x] Nixery's Nix-built container images

This covers most parts of the flow already!

----------

To make this work, there is some configuration on the Travis side.
Most importantly, the following environment variables have special
values:

* `GOOGLE_KEY`: This is set to a base64-encoded service account key to
  be used in the test.
* `GCS_SIGNING_PEM`: This is set to a base64-encoded signing key (in
  PEM) that is used for signing URLs.

Both of these are available to all branches in the Nixery repository.