### PR TITLE
Add iana-etc and cacert to the shell convenience package

### DIFF
--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -88,7 +88,7 @@ type BuildResult struct {
 //
 // * `shell`: Includes bash, coreutils and other common command-line tools
 func convenienceNames(packages []string) []string {
-	shellPackages := []string{"bashInteractive", "coreutils", "moreutils", "nano"}
+	shellPackages := []string{"bashInteractive", "cacert", "coreutils", "iana-etc", "moreutils", "nano"}
 
 	if packages[0] == "shell" {
 		return append(packages[1:], shellPackages...)


### PR DESCRIPTION
These probably should be part of every container image by default, but
adding it to the "shell" convenience name probably is our best bet for
now.