### PR TITLE
Sort requested packages in image name & spec

### DIFF
--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -50,12 +51,21 @@ type Image struct {
 //
 // It will expand convenience names under the hood (see the `convenienceNames`
 // function below).
+//
+// Once assembled the image structure uses a sorted representation of
+// the name. This is to avoid unnecessarily cache-busting images if
+// only the order of requested packages has changed.
 func ImageFromName(name string, tag string) Image {
-	packages := strings.Split(name, "/")
+	pkgs := strings.Split(name, "/")
+	expanded := convenienceNames(pkgs)
+
+	sort.Strings(pkgs)
+	sort.Strings(expanded)
+
 	return Image{
-		Name:     name,
+		Name:     strings.Join(pkgs, "/"),
 		Tag:      tag,
-		Packages: convenienceNames(packages),
+		Packages: expanded,
 	}
 }
 


### PR DESCRIPTION
Before this change, Nixery would pass on the image name unmodified to
Nix which would lead it to cache-bust the manifest and configuration
layers for images that are content-identical but have different
package ordering.

Note: While testing this I also came across a new example of #39 and verified that Docker is indeed pulling the same layers, next step is to dig into the Docker code and figure out what they use to determine if a layer is cached.

This fixes #38.