### PR TITLE
Ensure root user is known inside of container

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,8 @@ rec {
       # Create the build user/group required by Nix
       echo 'nixbld:x:30000:nixbld' >> /etc/group
       echo 'nixbld:x:30000:30000:nixbld:/tmp:/bin/bash' >> /etc/passwd
+      echo 'root:x:0:0:root:/root:/bin/bash' >> /etc/passwd
+      echo 'root:x:0:' >> /etc/group
 
       # Disable sandboxing to avoid running into privilege issues
       mkdir -p /etc/nix
@@ -80,6 +82,7 @@ rec {
     config.Cmd = [ "${nixery-launch-script}/bin/nixery" ];
     maxLayers = 96;
     contents = [
+      bashInteractive
       cacert
       coreutils
       git
@@ -89,6 +92,7 @@ rec {
       nixery-build-image
       nixery-launch-script
       openssh
+      zlib
     ];
   };
 }


### PR DESCRIPTION
This is required by git in cases where Nixery is configured with a
custom git repository.

I've also added a shell back into the image to make debugging a
running Nixery easier. It turns out some of the dependencies already
pull in bash anyways, so this is just surfacing it to $PATH.