### PR TITLE
Implement instance-independent manifest caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
       -e GOOGLE_APPLICATION_CREDENTIALS=/var/nixery/key.json \
       -e GCS_SIGNING_ACCOUNT="${GCS_SIGNING_ACCOUNT}" \
       -e GCS_SIGNING_KEY=/var/nixery/gcs.pem \
+      -e NIXERY_CHANNEL=nixos-unstable \
       ${IMG}
 
   # print all of the container's logs regardless of success

--- a/build-image/default.nix
+++ b/build-image/default.nix
@@ -20,11 +20,12 @@
 
   # Because of the insanity occuring below, this function must mirror
   # all arguments of build-image.nix.
-, pkgSource ? "nixpkgs!nixos-19.03"
+, srcType ? "nixpkgs"
+, srcArgs ? "nixos-19.03"
 , tag ? null, name ? null, packages ? null, maxLayers ? null
 }@args:
 
-let pkgs = import ./load-pkgs.nix { inherit pkgSource; };
+let pkgs = import ./load-pkgs.nix { inherit srcType srcArgs; };
 in with pkgs; rec {
 
   groupLayers = buildGoPackage {

--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,8 @@ rec {
 
   # Implementation of the image building & layering logic
   nixery-build-image = (import ./build-image {
-    pkgSource = "path!${<nixpkgs>}";
+    srcType = "path";
+    srcArgs = <nixpkgs>;
   }).wrapper;
 
   # Use mdBook to build a static asset page which Nixery can then

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -118,15 +118,16 @@ func BuildImage(ctx *context.Context, cfg *config.Config, cache *BuildCache, ima
 			return nil, err
 		}
 
+		srcType, srcArgs := cfg.Pkgs.Render(image.Tag)
+
 		args := []string{
 			"--timeout", cfg.Timeout,
 			"--argstr", "name", image.Name,
 			"--argstr", "packages", string(packages),
+			"--argstr", "srcType", srcType,
+			"--argstr", "srcArgs", srcArgs,
 		}
 
-		if cfg.Pkgs != nil {
-			args = append(args, "--argstr", "pkgSource", cfg.Pkgs.Render(image.Tag))
-		}
 		cmd := exec.Command("nixery-build-image", args...)
 
 		outpipe, err := cmd.StdoutPipe()

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -109,8 +109,8 @@ func convenienceNames(packages []string) []string {
 
 // Call out to Nix and request that an image be built. Nix will, upon success,
 // return a manifest for the container image.
-func BuildImage(ctx *context.Context, cfg *config.Config, cache *BuildCache, image *Image, bucket *storage.BucketHandle) (*BuildResult, error) {
-	resultFile, cached := cache.manifestFromCache(cfg.Pkgs, image)
+func BuildImage(ctx *context.Context, cfg *config.Config, cache *LocalCache, image *Image, bucket *storage.BucketHandle) (*BuildResult, error) {
+	resultFile, cached := manifestFromCache(ctx, bucket, cfg.Pkgs, cache, image)
 
 	if !cached {
 		packages, err := json.Marshal(image.Packages)
@@ -158,7 +158,7 @@ func BuildImage(ctx *context.Context, cfg *config.Config, cache *BuildCache, ima
 		log.Println("Finished Nix image build")
 
 		resultFile = strings.TrimSpace(string(stdout))
-		cache.cacheManifest(cfg.Pkgs, image, resultFile)
+		cacheManifest(ctx, bucket, cfg.Pkgs, cache, image, resultFile)
 	}
 
 	buildOutput, err := ioutil.ReadFile(resultFile)

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -110,7 +110,7 @@ func convenienceNames(packages []string) []string {
 // Call out to Nix and request that an image be built. Nix will, upon success,
 // return a manifest for the container image.
 func BuildImage(ctx *context.Context, cfg *config.Config, cache *BuildCache, image *Image, bucket *storage.BucketHandle) (*BuildResult, error) {
-	resultFile, cached := cache.manifestFromCache(image)
+	resultFile, cached := cache.manifestFromCache(cfg.Pkgs, image)
 
 	if !cached {
 		packages, err := json.Marshal(image.Packages)
@@ -158,7 +158,7 @@ func BuildImage(ctx *context.Context, cfg *config.Config, cache *BuildCache, ima
 		log.Println("Finished Nix image build")
 
 		resultFile = strings.TrimSpace(string(stdout))
-		cache.cacheManifest(image, resultFile)
+		cache.cacheManifest(cfg.Pkgs, image, resultFile)
 	}
 
 	buildOutput, err := ioutil.ReadFile(resultFile)

--- a/server/builder/cache.go
+++ b/server/builder/cache.go
@@ -14,13 +14,21 @@
 package builder
 
 import (
-	"github.com/google/nixery/config"
+	"context"
+	"io"
+	"log"
+	"os"
 	"sync"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/nixery/config"
 )
 
 type void struct{}
 
-type BuildCache struct {
+// LocalCache implements the structure used for local caching of
+// manifests and layer uploads.
+type LocalCache struct {
 	mmtx   sync.RWMutex
 	mcache map[string]string
 
@@ -28,8 +36,8 @@ type BuildCache struct {
 	lcache map[string]void
 }
 
-func NewCache() BuildCache {
-	return BuildCache{
+func NewCache() LocalCache {
+	return LocalCache{
 		mcache: make(map[string]string),
 		lcache: make(map[string]void),
 	}
@@ -38,7 +46,7 @@ func NewCache() BuildCache {
 // Has this layer hash already been seen by this Nixery instance? If
 // yes, we can skip upload checking and such because it has already
 // been done.
-func (c *BuildCache) hasSeenLayer(hash string) bool {
+func (c *LocalCache) hasSeenLayer(hash string) bool {
 	c.lmtx.RLock()
 	defer c.lmtx.RUnlock()
 	_, seen := c.lcache[hash]
@@ -46,19 +54,14 @@ func (c *BuildCache) hasSeenLayer(hash string) bool {
 }
 
 // Layer has now been seen and should be stored.
-func (c *BuildCache) sawLayer(hash string) {
+func (c *LocalCache) sawLayer(hash string) {
 	c.lmtx.Lock()
 	defer c.lmtx.Unlock()
 	c.lcache[hash] = void{}
 }
 
 // Retrieve a cached manifest if the build is cacheable and it exists.
-func (c *BuildCache) manifestFromCache(src config.PkgSource, image *Image) (string, bool) {
-	key := src.CacheKey(image.Packages, image.Tag)
-	if key == "" {
-		return "", false
-	}
-
+func (c *LocalCache) manifestFromLocalCache(key string) (string, bool) {
 	c.mmtx.RLock()
 	path, ok := c.mcache[key]
 	c.mmtx.RUnlock()
@@ -70,15 +73,85 @@ func (c *BuildCache) manifestFromCache(src config.PkgSource, image *Image) (stri
 	return path, true
 }
 
-// Adds the result of a manifest build to the cache, if the manifest
-// is considered cacheable.
-func (c *BuildCache) cacheManifest(src config.PkgSource, image *Image, path string) {
-	key := src.CacheKey(image.Packages, image.Tag)
+// Adds the result of a manifest build to the local cache, if the
+// manifest is considered cacheable.
+func (c *LocalCache) localCacheManifest(key, path string) {
+	c.mmtx.Lock()
+	c.mcache[key] = path
+	c.mmtx.Unlock()
+}
+
+// Retrieve a manifest from the cache(s). First the local cache is
+// checked, then the GCS-bucket cache.
+func manifestFromCache(ctx *context.Context, bucket *storage.BucketHandle, pkgs config.PkgSource, cache *LocalCache, image *Image) (string, bool) {
+	key := pkgs.CacheKey(image.Packages, image.Tag)
+	if key == "" {
+		return "", false
+	}
+
+	path, cached := cache.manifestFromLocalCache(key)
+	if cached {
+		return path, true
+	}
+
+	obj := bucket.Object("manifests/" + key)
+
+	// Probe whether the file exists before trying to fetch it.
+	_, err := obj.Attrs(*ctx)
+	if err != nil {
+		return "", false
+	}
+
+	r, err := obj.NewReader(*ctx)
+	if err != nil {
+		log.Printf("Failed to retrieve manifest '%s' from cache: %s\n", key, err)
+		return "", false
+	}
+	defer r.Close()
+
+	path = os.TempDir() + "/" + key
+	f, _ := os.Create(path)
+	defer f.Close()
+
+	_, err = io.Copy(f, r)
+	if err != nil {
+		log.Printf("Failed to read cached manifest for '%s': %s\n", key, err)
+	}
+
+	log.Printf("Retrieved manifest for '%s' (%s) from GCS\n", image.Name, key)
+	cache.localCacheManifest(key, path)
+
+	return path, true
+}
+
+func cacheManifest(ctx *context.Context, bucket *storage.BucketHandle, pkgs config.PkgSource, cache *LocalCache, image *Image, path string) {
+	key := pkgs.CacheKey(image.Packages, image.Tag)
 	if key == "" {
 		return
 	}
 
-	c.mmtx.Lock()
-	c.mcache[key] = path
-	c.mmtx.Unlock()
+	cache.localCacheManifest(key, path)
+
+	obj := bucket.Object("manifests/" + key)
+	w := obj.NewWriter(*ctx)
+
+	f, err := os.Open(path)
+	if err != nil {
+		log.Printf("failed to open '%s' manifest for cache upload: %s\n", image.Name, err)
+		return
+	}
+	defer f.Close()
+
+	size, err := io.Copy(w, f)
+	if err != nil {
+		log.Printf("failed to cache manifest sha1:%s: %s\n", key, err)
+		return
+	}
+
+	if err = w.Close(); err != nil {
+		log.Printf("failed to cache manifest sha1:%s: %s\n", key, err)
+		return
+	}
+
+	log.Printf("Cached manifest sha1:%s (%v bytes written)\n", key, size)
 }

--- a/server/config/pkgsource.go
+++ b/server/config/pkgsource.go
@@ -1,0 +1,155 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+package config
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// PkgSource represents the source from which the Nix package set used
+// by Nixery is imported. Users configure the source by setting one of
+// the supported environment variables.
+type PkgSource interface {
+	// Convert the package source into the representation required
+	// for calling Nix.
+	Render(tag string) (string, string)
+
+	// Create a key by which builds for this source and iamge
+	// combination can be cached.
+	//
+	// The empty string means that this value is not cacheable due
+	// to the package source being a moving target (such as a
+	// channel).
+	CacheKey(pkgs []string, tag string) string
+}
+
+type GitSource struct {
+	repository string
+}
+
+// Regex to determine whether a git reference is a commit hash or
+// something else (branch/tag).
+//
+// Used to check whether a git reference is cacheable, and to pass the
+// correct git structure to Nix.
+//
+// Note: If a user creates a branch or tag with the name of a commit
+// and references it intentionally, this heuristic will fail.
+var commitRegex = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func (g *GitSource) Render(tag string) (string, string) {
+	args := map[string]string{
+		"url": g.repository,
+	}
+
+	// The 'git' source requires a tag to be present. If the user
+	// has not specified one, it is assumed that the default
+	// 'master' branch should be used.
+	if tag == "latest" || tag == "" {
+		tag = "master"
+	}
+
+	if commitRegex.MatchString(tag) {
+		args["rev"] = tag
+	} else {
+		args["ref"] = tag
+	}
+
+	j, _ := json.Marshal(args)
+
+	return "git", string(j)
+}
+
+func (g *GitSource) CacheKey(pkgs []string, tag string) string {
+	// Only full commit hashes can be used for caching, as
+	// everything else is potentially a moving target.
+	if !commitRegex.MatchString(tag) {
+		return ""
+	}
+
+	unhashed := strings.Join(pkgs, "") + tag
+	hashed := fmt.Sprintf("%x", sha1.Sum([]byte(unhashed)))
+
+	return hashed
+}
+
+type NixChannel struct {
+	channel string
+}
+
+func (n *NixChannel) Render(tag string) (string, string) {
+	return "nixpkgs", n.channel
+}
+
+func (n *NixChannel) CacheKey(pkgs []string, tag string) string {
+	// Since Nix channels are downloaded from the nixpkgs-channels
+	// Github, users can specify full commit hashes as the
+	// "channel", in which case builds are cacheable.
+	if !commitRegex.MatchString(n.channel) {
+		return ""
+	}
+
+	unhashed := strings.Join(pkgs, "") + n.channel
+	hashed := fmt.Sprintf("%x", sha1.Sum([]byte(unhashed)))
+
+	return hashed
+}
+
+type PkgsPath struct {
+	path string
+}
+
+func (p *PkgsPath) Render(tag string) (string, string) {
+	return "path", p.path
+}
+
+func (p *PkgsPath) CacheKey(pkgs []string, tag string) string {
+	// Path-based builds are not currently cacheable because we
+	// have no local hash of the package folder's state easily
+	// available.
+	return ""
+}
+
+// Retrieve a package source from the environment. If no source is
+// specified, the Nix code will default to a recent NixOS channel.
+func pkgSourceFromEnv() (PkgSource, error) {
+	if channel := os.Getenv("NIXERY_CHANNEL"); channel != "" {
+		log.Printf("Using Nix package set from Nix channel %q\n", channel)
+		return &NixChannel{
+			channel: channel,
+		}, nil
+	}
+
+	if git := os.Getenv("NIXERY_PKGS_REPO"); git != "" {
+		log.Printf("Using Nix package set from git repository at %q\n", git)
+		return &GitSource{
+			repository: git,
+		}, nil
+	}
+
+	if path := os.Getenv("NIXERY_PKGS_PATH"); path != "" {
+		log.Printf("Using Nix package set from path %q\n", path)
+		return &PkgsPath{
+			path: path,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no valid package source has been specified")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -125,7 +125,7 @@ type registryHandler struct {
 	cfg    *config.Config
 	ctx    *context.Context
 	bucket *storage.BucketHandle
-	cache  *builder.BuildCache
+	cache  *builder.LocalCache
 }
 
 func (h *registryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/server/main.go
+++ b/server/main.go
@@ -190,7 +190,11 @@ func (h *registryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	cfg := config.FromEnv()
+	cfg, err := config.FromEnv()
+	if err != nil {
+		log.Fatalln("Failed to load configuration", err)
+	}
+
 	ctx := context.Background()
 	bucket := prepareBucket(&ctx, cfg)
 	cache := builder.NewCache()


### PR DESCRIPTION
This pull request implements caching of manifests to the bucket used for layer storage. Manifests are cached based on a key that is determined as a combination of the package source and image contents.

Note that manifests will only be cached for package sources which are **not** moving targets, i.e. either a full git commit hash of a private package repository or of nixpkgs.

This prevents rebuilds of identical manifests between different instances of Nixery.

See individual commits for details. This relates to #50 in that it implements the first step of the new proposed build process.