### PR TITLE
Add configuration option for the popularity URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: nix
 services:
   - docker
 env:
-  - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/88d9f776091896cfe57dc6fbdf246e7d27d5f105.tar.gz
+  - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/5271f8dddc0f2e54f55bd2fc1868c09ff72ac980.tar.gz
 before_script:
   - mkdir test-files
   - echo ${GOOGLE_KEY} | base64 -d > test-files/key.json

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ variables:
   for building
 * `NIX_TIMEOUT`: Number of seconds that any Nix builder is allowed to run
   (defaults to 60
+* `NIX_POPULARITY_URL`: URL to a file containing popularity data for the package set (see `popcount/`)
 * `GCS_SIGNING_KEY`: A Google service account key (in PEM format) that can be
   used to sign Cloud Storage URLs
 * `GCS_SIGNING_ACCOUNT`: Google service account ID that the signing key belongs

--- a/build-image/build-image.nix
+++ b/build-image/build-image.nix
@@ -35,6 +35,9 @@
   # layers. To allow for some extensibility (via additional layers),
   # the default here is set to something a little less than that.
   maxLayers ? 96,
+  # Popularity data for layer solving is fetched from the URL passed
+  # in here.
+  popularityUrl ? "https://storage.googleapis.com/nixery-layers/popularity/popularity-19.03.173490.5271f8dddc0.json",
 
   ...
 }:
@@ -101,10 +104,7 @@ let
         fetched = (map (deepFetch pkgs) (fromJSON packages));
     in foldl' splitter init fetched;
 
-  popularity = builtins.fetchurl {
-    url = "https://storage.googleapis.com/nixery-layers/popularity/nixos-19.03-20190812.json";
-    sha256 = "16sxd49vqqg2nrhwynm36ba6bc2yff5cd5hf83wi0hanw5sx3svk";
-  };
+  popularity = builtins.fetchurl popularityUrl;
 
   # Before actually creating any image layers, the store paths that need to be
   # included in the image must be sorted into the layers that they should go

--- a/build-image/default.nix
+++ b/build-image/default.nix
@@ -22,7 +22,7 @@
   # all arguments of build-image.nix.
 , srcType ? "nixpkgs"
 , srcArgs ? "nixos-19.03"
-, tag ? null, name ? null, packages ? null, maxLayers ? null
+, tag ? null, name ? null, packages ? null, maxLayers ? null, popularityUrl ? null
 }@args:
 
 let pkgs = import ./load-pkgs.nix { inherit srcType srcArgs; };

--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,7 @@ rec {
   # are installing Nixery directly.
   nixery-bin = writeShellScriptBin "nixery" ''
     export WEB_DIR="${nixery-book}"
+    export PATH="${nixery-build-image}/bin:$PATH"
     exec ${nixery-server}/bin/nixery
   '';
 

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -21,24 +21,6 @@
 { fetchFromGitHub, mdbook, runCommand, rustPlatform }:
 
 let
-  # nixpkgs currently has an old version of mdBook. A new version is
-  # built here, but eventually the update will be upstreamed
-  # (nixpkgs#65890)
-  mdbook = rustPlatform.buildRustPackage rec {
-    name = "mdbook-${version}";
-    version = "0.3.1";
-    doCheck = false;
-
-    src = fetchFromGitHub {
-      owner = "rust-lang-nursery";
-      repo = "mdBook";
-      rev = "v${version}";
-      sha256 = "0py69267jbs6b7zw191hcs011cm1v58jz8mglqx3ajkffdfl3ghw";
-    };
-
-    cargoSha256 = "0qwhc42a86jpvjcaysmfcw8kmwa150lmz01flmlg74g6qnimff5m";
-  };
-
   nix-1p = fetchFromGitHub {
     owner = "tazjin";
     repo = "nix-1p";

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -134,6 +134,10 @@ func BuildImage(ctx *context.Context, cfg *config.Config, cache *LocalCache, ima
 			"--argstr", "srcArgs", srcArgs,
 		}
 
+		if cfg.PopUrl != "" {
+			args = append(args, "--argstr", "popularityUrl", cfg.PopUrl)
+		}
+
 		cmd := exec.Command("nixery-build-image", args...)
 
 		outpipe, err := cmd.StdoutPipe()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	Pkgs    PkgSource                 // Source for Nix package set
 	Timeout string                    // Timeout for a single Nix builder (seconds)
 	WebDir  string                    // Directory with static web assets
+	PopUrl  string                    // URL to the Nix package popularity count
 }
 
 func FromEnv() (*Config, error) {
@@ -83,5 +84,6 @@ func FromEnv() (*Config, error) {
 		Signing: signingOptsFromEnv(),
 		Timeout: getConfig("NIX_TIMEOUT", "Nix builder timeout", "60"),
 		WebDir:  getConfig("WEB_DIR", "Static web file dir", ""),
+		PopUrl:  os.Getenv("NIX_POPULARITY_URL"),
 	}, nil
 }


### PR DESCRIPTION
See individual commits.

I experimented with doing stuff like automatically templating `lib.version` into the popularity URL, but that breaks for anything other than non-trivial use cases.

This fixes #53.