### PR TITLE
Apply GZIP compression to all image layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     docker run -d -p 8080:8080 --name nixery \
       -v ${PWD}/test-files:/var/nixery \
       -e PORT=8080 \
-      -e BUCKET=nixery-layers \
+      -e BUCKET=nixery-ci-tests \
       -e GOOGLE_CLOUD_PROJECT=nixery \
       -e GOOGLE_APPLICATION_CREDENTIALS=/var/nixery/key.json \
       -e GCS_SIGNING_ACCOUNT="${GCS_SIGNING_ACCOUNT}" \

--- a/build-image/build-image.nix
+++ b/build-image/build-image.nix
@@ -126,9 +126,9 @@ let
   # Image layer that contains the symlink forest created above. This
   # must be included in the image to ensure that the filesystem has a
   # useful layout at runtime.
-  symlinkLayer = runCommand "symlink-layer.tar" {} ''
+  symlinkLayer = runCommand "symlink-layer.tar.gz" {} ''
     cp -r ${contentsEnv}/ ./layer
-    tar --transform='s|^\./||' -C layer --sort=name --mtime="@$SOURCE_DATE_EPOCH" --owner=0 --group=0 -cf $out .
+    tar --transform='s|^\./||' -C layer --sort=name --mtime="@$SOURCE_DATE_EPOCH" --owner=0 --group=0 -czf $out .
   '';
 
   # Metadata about the symlink layer which is required for serving it.

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -270,7 +270,7 @@ func prepareLayers(ctx context.Context, s *State, image *Image, result *ImageRes
 		} else {
 			lh := l.Hash()
 			lw := func(w io.Writer) error {
-				return tarStorePaths(&l, w)
+				return packStorePaths(&l, w)
 			}
 
 			entry, err := uploadHashLayer(ctx, s, lh, lw)

--- a/server/manifest/manifest.go
+++ b/server/manifest/manifest.go
@@ -15,7 +15,7 @@ const (
 
 	// media types
 	manifestType = "application/vnd.docker.distribution.manifest.v2+json"
-	layerType    = "application/vnd.docker.image.rootfs.diff.tar"
+	layerType    = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 	configType   = "application/vnd.docker.container.image.v1+json"
 
 	// image config constants
@@ -102,7 +102,7 @@ func Manifest(layers []Entry) (json.RawMessage, ConfigLayer) {
 
 	hashes := make([]string, len(layers))
 	for i, l := range layers {
-		l.MediaType = "application/vnd.docker.image.rootfs.diff.tar"
+		l.MediaType = layerType
 		layers[i] = l
 		hashes[i] = l.Digest
 	}

--- a/server/manifest/manifest.go
+++ b/server/manifest/manifest.go
@@ -29,9 +29,10 @@ type Entry struct {
 	Size      int64  `json:"size"`
 	Digest    string `json:"digest"`
 
-	// This field is internal to Nixery and not part of the
+	// These fields are internal to Nixery and not part of the
 	// serialised entry.
 	MergeRating uint64 `json:"-"`
+	TarHash     string `json:",omitempty"`
 }
 
 type manifest struct {
@@ -102,9 +103,10 @@ func Manifest(layers []Entry) (json.RawMessage, ConfigLayer) {
 
 	hashes := make([]string, len(layers))
 	for i, l := range layers {
+		hashes[i] = l.TarHash
 		l.MediaType = layerType
+		l.TarHash = ""
 		layers[i] = l
-		hashes[i] = l.Digest
 	}
 
 	c := configLayer(hashes)


### PR DESCRIPTION
This needs some evaluation (and maybe feature-gating). There are a couple of noteworthy things:

* Cache compatibility is broken (essentially Nixery's bucket needs to be wiped if moving from non-gzip to gzip - in theory the layer objects can be kept around, but a user would probably want all manifests & builds purged to make sure that compressed versions are used)

* Whether the tradeoff between CPU time vs. upload time is worth it might be dependent on the situation (e.g. inside GCP, the additional data size might not matter that much if it's only moving between nodes & GCS)

This fixes #62