### PR TITLE
fix(build): Only take the first matching hash for source hashing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ rec {
   # builds to distinguish errors between deployed versions, see
   # server/logs.go for details.
   nixery-src-hash = pkgs.runCommand "nixery-src-hash" {} ''
-    echo ${./.} | grep -Eo '[a-z0-9]{32}' > $out
+    echo ${./.} | grep -Eo '[a-z0-9]{32}' | head -c 32 > $out
   '';
 
   # Go implementation of the Nixery server which implements the


### PR DESCRIPTION
Some Nix download mechanisms will add a second hash in the store path,
which had been added to the source hash output (breaking argument
interpolation).