### PR TITLE
fix(builder): Fix minor logging switcharoo

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -201,7 +201,7 @@ func callNix(program, image string, args []string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	go logNix(program, image, errpipe)
+	go logNix(image, program, errpipe)
 
 	if err = cmd.Start(); err != nil {
 		log.WithError(err).WithFields(log.Fields{


### PR DESCRIPTION
The `cmd` and `image` fields ended up swapped in the log output here.