### PR TITLE
fix(popcount): Fix nix-build -A nixery-popcount

### DIFF
--- a/popcount/default.nix
+++ b/popcount/default.nix
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{ go, stdenv }:
+{ buildGoPackage }:
 
-stdenv.mkDerivation {
+buildGoPackage {
   name = "nixery-popcount";
 
-  buildInputs = [ go ];
-  phases = [ "buildPhase" ];
-  buildPhase = ''
-    mkdir -p $out/bin
-    go build -o $out/bin/popcount ${./popcount.go}
-  '';
+  src = ./.;
+
+  goPackagePath = "github.com/google/nixery/popcount";
+  doCheck = true;
 }


### PR DESCRIPTION
Previously, this was failing as follows:

```
these derivations will be built:
  /nix/store/7rbrf06phkiyz31dwpq88x920zjhnw0c-nixery-popcount.drv
building '/nix/store/7rbrf06phkiyz31dwpq88x920zjhnw0c-nixery-popcount.drv'...
building
warning: GOPATH set to GOROOT (/nix/store/4859cp1v7zqcqh43jkqsayl4wrz3g6hp-go-1.13.4/share/go) has no effect
failed to initialize build cache at /homeless-shelter/.cache/go-build: mkdir /homeless-shelter: permission denied
builder for '/nix/store/7rbrf06phkiyz31dwpq88x920zjhnw0c-nixery-popcount.drv' failed with exit code 1
error: build of '/nix/store/7rbrf06phkiyz31dwpq88x920zjhnw0c-nixery-popcount.drv' failed
```