### PR TITLE
chore(nix): update channel 19.03 -> 20.03

### DIFF
--- a/docs/src/caching.md
+++ b/docs/src/caching.md
@@ -29,7 +29,7 @@ Manifest caching *only* applies in the following cases:
 Manifest caching *never* applies in the following cases:
 
 * package source specification is a local file path (i.e. `NIXERY_PKGS_PATH`)
-* package source specification is a NixOS channel (e.g. `NIXERY_CHANNEL=nixos-19.03`)
+* package source specification is a NixOS channel (e.g. `NIXERY_CHANNEL=nixos-20.03`)
 * package source specification is a git branch or tag (e.g. `staging`, `master` or `latest`)
 
 It is thus always preferable to request images from a fully-pinned package

--- a/docs/src/nixery.md
+++ b/docs/src/nixery.md
@@ -54,7 +54,7 @@ own instance of Nixery.
 ### Which revision of `nixpkgs` is used for the builds?
 
 The instance at `nixery.dev` tracks a recent NixOS channel, currently NixOS
-19.03. The channel is updated several times a day.
+20.03. The channel is updated several times a day.
 
 Private registries might be configured to track a different channel (such as
 `nixos-unstable`) or even track a git repository with custom packages.

--- a/docs/src/run-your-own.md
+++ b/docs/src/run-your-own.md
@@ -44,7 +44,7 @@ be performed for trivial things.
 However if you are running a private Nixery, chances are high that you intend to
 use it with your own packages. There are three options available:
 
-1. Specify an upstream Nix/NixOS channel[^1], such as `nixos-19.03` or
+1. Specify an upstream Nix/NixOS channel[^1], such as `nixos-20.03` or
    `nixos-unstable`.
 2. Specify your own git-repository with a custom package set[^2]. This makes it
    possible to pull different tags, branches or commits by modifying the image
@@ -73,7 +73,7 @@ You must set *all* of these:
 * `BUCKET`: [Google Cloud Storage][gcs] bucket to store & serve image layers
 * `PORT`: HTTP port on which Nixery should listen
 
-You may set *one* of these, if unset Nixery defaults to `nixos-19.03`:
+You may set *one* of these, if unset Nixery defaults to `nixos-20.03`:
 
 * `NIXERY_CHANNEL`: The name of a Nix/NixOS channel to use for building
 * `NIXERY_PKGS_REPO`: URL of a git repository containing a package set (uses

--- a/prepare-image/prepare-image.nix
+++ b/prepare-image/prepare-image.nix
@@ -24,7 +24,7 @@
 {
   # Description of the package set to be used (will be loaded by load-pkgs.nix)
   srcType ? "nixpkgs",
-  srcArgs ? "nixos-19.03",
+  srcArgs ? "nixos-20.03",
   system ? "x86_64-linux",
   importArgs ? { },
   # Path to load-pkgs.nix


### PR DESCRIPTION
Use a NixOS / NixPkgs release that's actually being supported and regularly updated.

#### Motivation

- One might want to pull containers with up-to-date software from nixery. (I do.)
- NixOS 19.03 has been unsupported for ~ half a year now.
- Section [Which revision of nixpkgs is used for the builds?](https://nixery.dev/nixery.html#which-revision-of-nixpkgs-is-used-for-the-builds) in the FAQ claims about [nixery.dev](https://nixery.dev):
  > The channel is updated several times a day.

  That is only useful if the upstream channel content actually changes now and then. NixPkgs branch [`release-19.03`](https://github.com/NixOS/nixpkgs/commits/release-19.03) has recently received only around 3 changes per month.

#### Note

:warning: This change is completely untested, as I don't have a Nixery instance of my own.