### PR TITLE
fix(build): Don't use Cachix as the binary cache during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - echo ${GOOGLE_KEY} | base64 -d > test-files/key.json
   - echo ${GCS_SIGNING_PEM} | base64 -d > test-files/gcs.pem
   - nix-env -f '<nixpkgs>' -iA cachix -A go
-  - cachix use nixery
 script:
   - test -z $(gofmt -l server/ build-image/)
   - nix-build --arg maxLayers 1 | cachix push nixery


### PR DESCRIPTION
Permission changes in the Travis CI Nix builders have caused this to
start failing, as the build user now has insufficient permissions to
use caches.

There may be a way to change the permissions instead, but in the
meantime we will just cause things to rebuild.