### PR TITLE
refactor(main): Split HTTP handlers into separate functions

### DIFF
--- a/config/pkgsource.go
+++ b/config/pkgsource.go
@@ -140,7 +140,7 @@ func pkgSourceFromEnv() (PkgSource, error) {
 	}
 
 	if git := os.Getenv("NIXERY_PKGS_REPO"); git != "" {
-		log.WithField("repo", git).Info("using NIx package set from git repository")
+		log.WithField("repo", git).Info("using Nix package set from git repository")
 
 		return &GitSource{
 			repository: git,


### PR DESCRIPTION
There is a new handler coming up to fix #102 and I want to avoid falling into the classic Go trap of creating thousand-line functions.