### PR TITLE
Implement fetching of manifests by digest

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy of
@@ -159,7 +159,7 @@ func (h *registryHandler) serveManifestTag(w http.ResponseWriter, r *http.Reques
 // serveLayer serves an image layer from storage (if it exists).
 func (h *registryHandler) serveLayer(w http.ResponseWriter, r *http.Request, digest string) {
 	storage := h.state.Storage
-	err := storage.ServeLayer(digest, r, w)
+	err := storage.Serve(digest, r, w)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"layer":   digest,

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -83,13 +83,13 @@ func (b *FSBackend) Move(ctx context.Context, old, new string) error {
 	return os.Rename(path.Join(b.path, old), newpath)
 }
 
-func (b *FSBackend) ServeLayer(digest string, r *http.Request, w http.ResponseWriter) error {
+func (b *FSBackend) Serve(digest string, r *http.Request, w http.ResponseWriter) error {
 	p := path.Join(b.path, "layers", digest)
 
 	log.WithFields(log.Fields{
-		"layer": digest,
-		"path":  p,
-	}).Info("serving layer from filesystem")
+		"digest": digest,
+		"path":   p,
+	}).Info("serving blob from filesystem")
 
 	http.ServeFile(w, r, p)
 	return nil

--- a/storage/gcs.go
+++ b/storage/gcs.go
@@ -150,18 +150,18 @@ func (b *GCSBackend) Move(ctx context.Context, old, new string) error {
 	return nil
 }
 
-func (b *GCSBackend) ServeLayer(digest string, r *http.Request, w http.ResponseWriter) error {
+func (b *GCSBackend) Serve(digest string, r *http.Request, w http.ResponseWriter) error {
 	url, err := b.constructLayerUrl(digest)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
-			"layer":  digest,
+			"digest": digest,
 			"bucket": b.bucket,
 		}).Error("failed to sign GCS URL")
 
 		return err
 	}
 
-	log.WithField("layer", digest).Info("redirecting layer request to GCS bucket")
+	log.WithField("digest", digest).Info("redirecting blob request to GCS bucket")
 
 	w.Header().Set("Location", url)
 	w.WriteHeader(303)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy of
@@ -46,6 +46,6 @@ type Backend interface {
 	Move(ctx context.Context, old, new string) error
 
 	// Serve provides a handler function to serve HTTP requests
-	// for layers in the storage backend.
-	ServeLayer(digest string, r *http.Request, w http.ResponseWriter) error
+	// for objects in the storage backend.
+	Serve(digest string, r *http.Request, w http.ResponseWriter) error
 }


### PR DESCRIPTION
This series of changes makes it possible for clients to fetch (previously created) manifests by digest. This allows for compatibility with containerd.

Please see the individual commits for details.

This fixes #102 

cc @jonjohnsonjr 