### PR TITLE
chore(ci): remove GCS_SIGNING_PEM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
   - echo "Running Nixery CI build on $(uname -m)"
   - mkdir test-files
   - echo ${GOOGLE_KEY} | base64 -d > test-files/key.json
-  - echo ${GCS_SIGNING_PEM} | base64 -d > test-files/gcs.pem
   - nix-env -f '<nixpkgs>' -iA -A go
 script:
   - test -z $(gofmt -l server/ build-image/)


### PR DESCRIPTION
There's nothing in here reading from a gcs.pem, so we shouldn't populate
it.
Currently, Nixery uses the key material inside the file passed via
GOOGLE_APPLICATION_CREDENTIALS.