### PR TITLE
feat(ci): remove unneeded permissions: read-all

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request: {}
-permissions: "read-all"
 env:
   NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/0a40a3999eb4d577418515da842a2622a64880c5.tar.gz"
 jobs:


### PR DESCRIPTION
We don't intend to label, authenticate or whatever with the
GITHUB_TOKEN, so there's not really a reason to give any broader
permissions than the defaults.