### PR TITLE
chore(ci): Remove unnecessary commands from new CI setup

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,20 +11,15 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: "Do we have Docker?"
-        run: |
-          docker ps -a
       - name: Install Nix
         uses: cachix/install-nix-action@v13
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Prepare environment
-        run: |
-          mkdir test-storage
-          nix-env -f '<nixpkgs>' -iA go
+        run: nix-env -f '<nixpkgs>' -iA go
       - name: Check formatting
         run: "test -z $(gofmt -l .)"
       - name: Build Nixery
-        run: "nix-build --arg maxLayers 2"
+        run: "nix-build --arg maxLayers 2 --no-out-link"
       - name: Run integration test
         run: scripts/integration-test.sh


### PR DESCRIPTION
* remove a step that was not supposed to be committed ("Do we have Docker?")
* remove setup of old temporary storage directory (now done in integration script test instead)
* skip creation of out-link for initial Nixery build (to avoid cache-busting on the second build)