### PR TITLE
feat(ci): don't mount /var/cache/nixery from tmpfs into docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ debug/
 *.pem
 *.p12
 *.json
+
+# Created by the integration test
+var-cache-nixery


### PR DESCRIPTION
With https://github.com/google/nixery/pull/127, nixery will use extended
attributes to store metadata (when using local storage).

Right now, our integration test mounts a tmpfs to /var/cache/nixery.
However, *user* xattrs aren't supported with tmpfs [1], so setting
xattrs would fail.

To workaround this, use a folder in the current working directory and
hope it's backed by something supporting user xattrs (which is the case
for GitHub Actions).

[1]: https://man7.org/linux/man-pages/man5/tmpfs.5.html#NOTES