### PR TITLE
feat(prepare-image): Ensure /usr/bin/env is always present

### DIFF
--- a/prepare-image/prepare-image.nix
+++ b/prepare-image/prepare-image.nix
@@ -132,6 +132,18 @@ let
   contentsEnv = symlinkJoin {
     name = "bulk-layers";
     paths = allContents.contents;
+
+    # Ensure that there is always a /usr/bin/env for shell scripts
+    # that require it.
+    #
+    # Note that images which do not actually contain `coreutils` will
+    # still have this symlink, but it will be dangling.
+    #
+    # TODO(tazjin): Don't link this if coreutils is not included.
+    postBuild = ''
+      mkdir -p $out/usr/bin
+      ln -s ${coreutils}/bin/env $out/usr/bin/env
+    '';
   };
 
   # Image layer that contains the symlink forest created above. This


### PR DESCRIPTION
This is required by common patterns in shell scripts.

There are some caveats around this. Adding logic to filter whether coreutils is included in an image would slow down the Nix evaluation, so the link is currently created even in cases where it doesn't point to anything.

Fixes #109