### PR TITLE
feat(nixery): make default tag configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ variables:
 * `NIXERY_CHANNEL`: The name of a Nix/NixOS channel to use for building
 * `NIXERY_PKGS_REPO`: URL of a git repository containing a package set (uses
   locally configured SSH/git credentials)
+* `NIXERY_DEFAULT_TAG`: rev/ref to use as the default for `latest`/empty
 * `NIXERY_PKGS_PATH`: A local filesystem path containing a Nix package set to
   use for building
 * `NIXERY_STORAGE_BACKEND`: The type of backend storage to use, currently

--- a/config/pkgsource.go
+++ b/config/pkgsource.go
@@ -49,10 +49,14 @@ func (g *GitSource) Render(tag string) (string, string) {
 		"url": g.repository,
 	}
 
-	// The 'git' source requires a tag to be present. If the user
-	// has not specified one, it is assumed that 'HEAD' should be used.
+	// If the user has not specified a non-default tag,
+	// use $NIXERY_DEFAULT_TAG or HEAD as the tag.
 	if tag == "latest" || tag == "" {
-		tag = "HEAD"
+		if default_tag := os.Getenv("NIXERY_DEFAULT_TAG"); default_tag != "" {
+			tag = default_tag
+		} else {
+			tag = "HEAD"
+		}
 	}
 
 	if commitRegex.MatchString(tag) {


### PR DESCRIPTION
closes #174 

obsoletes #176

This gives users of all implementations, forks, and versions of Nix a way to not only work around oddities and bugs but also allows falling back to a non-HEAD ref like `nixos-unstable`.